### PR TITLE
fix: make get_pending_deposit_intent use database

### DIFF
--- a/crates/node/src/handlers/deposit/create_deposit.rs
+++ b/crates/node/src/handlers/deposit/create_deposit.rs
@@ -144,8 +144,17 @@ impl DepositIntentState {
         Ok((deposit_tracking_id, deposit_address.to_string()))
     }
 
-    pub fn get_pending_deposit_intents(&self) -> Vec<DepositIntent> {
-        self.pending_intents.clone()
+    pub fn get_pending_deposit_intents<N: Network, D: Db, O: Oracle>(
+        &self,
+        node: &NodeState<N, D, O>,
+    ) -> Vec<DepositIntent> {
+        match node.db.get_all_deposit_intents() {
+            Ok(intents) => intents,
+            Err(e) => {
+                error!("Failed to fetch deposit intents from db: {}", e);
+                Vec::new()
+            }
+        }
     }
 
     pub fn update_user_balance<N: Network, D: Db, O: Oracle>(

--- a/crates/node/src/handlers/deposit/handler.rs
+++ b/crates/node/src/handlers/deposit/handler.rs
@@ -45,7 +45,7 @@ impl<N: Network, D: Db, O: Oracle> Handler<N, D, O> for DepositIntentState {
                 request: SelfRequest::GetPendingDepositIntents,
                 response_channel,
             }) => {
-                let response = self.get_pending_deposit_intents();
+                let response = self.get_pending_deposit_intents(node);
                 if let Some(response_channel) = response_channel {
                     response_channel
                         .send(SelfResponse::GetPendingDepositIntentsResponse { intents: response })


### PR DESCRIPTION
- **refactor: make esplora confirmation depth configurable**
- **fix: ensure rocksdb persists for docker compose**
- **fix: make get_pending_deposit_intent use database**
